### PR TITLE
refactor: isolate backend layers

### DIFF
--- a/backend/query/auth.sql
+++ b/backend/query/auth.sql
@@ -1,0 +1,14 @@
+-- name: auth.ensureUserTable
+CREATE TABLE IF NOT EXISTS T_USER (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  name TEXT,
+  email TEXT,
+  role TEXT,
+  last_login_at TIMESTAMP
+);
+
+-- name: auth.insertDemoUser
+INSERT INTO T_USER (username, password_hash, name, email, role)
+VALUES (:u, :p, :n, :e, :r);

--- a/backend/query/transaction.sql
+++ b/backend/query/transaction.sql
@@ -1,0 +1,8 @@
+-- name: tx.ensureTable
+CREATE TABLE IF NOT EXISTS test_transaction (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    value TEXT UNIQUE
+);
+
+-- name: tx.insertValue
+INSERT INTO test_transaction (value) VALUES (:val);

--- a/backend/query/users.sql
+++ b/backend/query/users.sql
@@ -1,5 +1,5 @@
 -- name: user.selectByUsername
-SELECT id, username, name, email, role
+SELECT id, username, password_hash, name, email, role
 FROM T_USER
 WHERE username = :u;
 
@@ -8,4 +8,7 @@ SELECT COUNT(*) AS cnt FROM T_USER;
 
 -- name: sys.ping
 SELECT 1;
+
+-- name: sys.oraclePing
+SELECT 1 FROM DUAL;
 

--- a/backend/router/AuthRouter.py
+++ b/backend/router/AuthRouter.py
@@ -2,347 +2,42 @@
 파일명: backend/router/AuthRouter.py
 작성자: Codex CLI
 갱신일: 2025-09-07
-설명: 인증/세션/토큰 발급 라우트. 표준 응답·CSRF·레이트리밋 적용.
+설명: 인증 API 라우터. 서비스 계층 호출만 수행.
 """
 
-import os
-import json
-import time
-import uuid
-from collections import deque
-from typing import Optional
-
-import bcrypt
 from fastapi import APIRouter, Depends, Request
-from fastapi.responses import JSONResponse, Response
 
-from lib.Auth import AuthConfig, Token, createAccessToken, getCurrentUser
-from lib.Database import dbManagers
-from lib.Response import errorResponse, successResponse
-from lib.Logger import logger
-from lib.I18n import detect_locale, t as i18n_t
-from lib.RequestContext import get_request_id
-
+from lib.Auth import getCurrentUser
+from service import AuthService
 
 router = APIRouter(prefix="/api/v1/auth", tags=["auth"])
 
 
-def _cfg(key: str, default: Optional[str] = None) -> str:
-    try:
-        from .. import server as server_mod  # when imported as package
-    except Exception:  # pragma: no cover
-        import server as server_mod  # when running as module from backend/
-    section = server_mod.config["AUTH"]
-    return section.get(key, default) if default is not None else section[key]
-
-
-# Simple in-memory rate limiter (per-process)
-class _RateLimiter:
-    def __init__(self, limit: int = 5, window_sec: int = 60):
-        self.limit = limit
-        self.window = window_sec
-        self.store = {}
-
-    def _now(self):
-        return time.monotonic()
-
-    def hit(self, key: str):
-        now = self._now()
-        dq = self.store.get(key)
-        if dq is None:
-            dq = deque()
-            self.store[key] = dq
-        # drop old
-        while dq and now - dq[0] > self.window:
-            dq.popleft()
-        if len(dq) >= self.limit:
-            # seconds until reset
-            retry_after = max(1, int(self.window - (now - dq[0])))
-            return False, retry_after
-        dq.append(now)
-        return True, 0
-
-
-_rl = _RateLimiter(limit=int(os.getenv("AUTH_RATE_LIMIT", "5")), window_sec=60)
-
-
-def _rate_limit(request: Request, username: Optional[str] = None) -> Optional[Response]:
-    ip = getattr(request.client, "host", "unknown")
-    keys = [f"ip:{ip}"]
-    if username:
-        keys.append(f"user:{username}")
-    for k in keys:
-        ok, retry_after = _rl.hit(k)
-        if not ok:
-            return JSONResponse(
-                status_code=429,
-                content=errorResponse(
-                    message="too many requests", code="AUTH_429_RATE_LIMIT"
-                ),
-                headers={"Retry-After": str(retry_after)},
-            )
-    return None
-
-
-async def _ensure_auth_tables():
-    if "main_db" not in dbManagers:
-        return
-    db = dbManagers["main_db"]
-    await db.execute(
-        """
-        CREATE TABLE IF NOT EXISTS T_USER (
-          id INTEGER PRIMARY KEY AUTOINCREMENT,
-          username TEXT UNIQUE NOT NULL,
-          password_hash TEXT NOT NULL,
-          name TEXT,
-          email TEXT,
-          role TEXT,
-          last_login_at TIMESTAMP
-        )
-        """
-    )
-    # seed demo account if absent
-    row = await db.fetchOne("SELECT username FROM T_USER WHERE username = :u", {"u": "demo"})
-    if not row:
-        hashed = bcrypt.hashpw(b"password123", bcrypt.gensalt()).decode()
-        await db.execute(
-            "INSERT INTO T_USER (username, password_hash, name, email, role) VALUES (:u,:p,:n,:e,:r)",
-            {"u": "demo", "p": hashed, "n": "Demo User", "e": "demo@example.com", "r": "admin"},
-        )
-
-
-def _validate_input(request: Request, username: str, password: str) -> Optional[Response]:
-    loc = detect_locale(request)
-    if not isinstance(username, str) or not isinstance(password, str):
-        return JSONResponse(
-            status_code=422,
-            content=errorResponse(
-                message=i18n_t("error.invalid_input", "invalid input", loc), result=None, code="AUTH_422_INVALID_INPUT"
-            ),
-            headers={"WWW-Authenticate": "Cookie"},
-        )
-    if len(username) < 3 or len(password) < 8:
-        return JSONResponse(
-            status_code=422,
-            content=errorResponse(
-                message=i18n_t("error.invalid_input", "invalid input", loc), result=None, code="AUTH_422_INVALID_INPUT"
-            ),
-            headers={"WWW-Authenticate": "Cookie"},
-        )
-    return None
-
-
-def _require_csrf(request: Request) -> Optional[Response]:
-    header_name = _cfg("csrf_header", "X-CSRF-Token")
-    expected = request.session.get("csrf")
-    provided = request.headers.get(header_name)
-    if not expected or not provided or expected != provided:
-        return JSONResponse(
-            status_code=403,
-            content=errorResponse(
-                message=i18n_t("error.csrf_required", "csrf required", detect_locale(request)), result=None, code="AUTH_403_CSRF_REQUIRED"
-            ),
-            headers={"WWW-Authenticate": "Cookie"},
-        )
-    return None
-
-
 @router.post("/login", status_code=204)
 async def login(request: Request):
-    """
-    설명: 쿠키 세션 로그인. 성공 시 세션 회전 및 CSRF 발급.
-    갱신일: 2025-09-07
-    """
-    await _ensure_auth_tables()
-    body = await request.json()
-    username = body.get("username")
-    password = body.get("password")
-    remember = bool(body.get("rememberMe", False))
-
-    invalid = _validate_input(request, username, password)
-    if invalid is not None:
-        return invalid
-
-    if "main_db" not in dbManagers:
-        loc = detect_locale(request)
-        return JSONResponse(
-            status_code=500,
-            content=errorResponse(message=i18n_t("db.unavailable", "db unavailable", loc), code="AUTH_500_DB"),
-        )
-    db = dbManagers["main_db"]
-    user = await db.fetchOne(
-        "SELECT username, password_hash, name FROM T_USER WHERE username = :u",
-        {"u": username},
-    )
-    if not user:
-        logger.info("auth.login.fail username")
-        limited = _rate_limit(request, username=username)
-        if limited is not None:
-            return limited
-        return JSONResponse(
-            status_code=401,
-            content=errorResponse(message=i18n_t("error.invalid_credentials", "invalid credentials", detect_locale(request)), code="AUTH_401_INVALID"),
-            headers={"WWW-Authenticate": "Cookie"},
-        )
-    if not bcrypt.checkpw(password.encode(), user["password_hash"].encode()):
-        logger.info("auth.login.fail password")
-        limited = _rate_limit(request, username=username)
-        if limited is not None:
-            return limited
-        return JSONResponse(
-            status_code=401,
-            content=errorResponse(message=i18n_t("error.invalid_credentials", "invalid credentials", detect_locale(request)), code="AUTH_401_INVALID"),
-            headers={"WWW-Authenticate": "Cookie"},
-        )
-
-    # rotate session by clearing and setting new data
-    request.session.clear()
-    request.session["userId"] = user["username"]
-    request.session["name"] = user.get("name") or None
-    # issue csrf
-    csrf = uuid.uuid4().hex
-    request.session["csrf"] = csrf
-
-    response = Response(status_code=204)
-    # audit log (success)
-    try:
-        logger.info(
-            json.dumps(
-                {
-                    "event": "auth.login.success",
-                    "userId": user["username"],
-                    "ip": getattr(request.client, "host", None),
-                    "requestId": get_request_id(),
-                },
-                ensure_ascii=False,
-            )
-        )
-    except Exception:
-        pass
-    # SessionMiddleware will set cookie when session modified. For remember, we can't change max_age per request here.
-    # Optionally set a helper cookie for UI to know long-lived session preference.
-    if remember:
-        response.set_cookie("rememberMe", "1", max_age=60 * 60 * 24 * 30, httponly=False)
-    return response
+    return await AuthService.login(request)
 
 
 @router.post("/logout", status_code=204)
 async def logout(request: Request):
-    """
-    설명: CSRF 검증 후 세션 로그아웃 및 쿠키 삭제.
-    갱신일: 2025-09-07
-    """
-    # CSRF required for cookie-mode unsafe request
-    csrf_error = _require_csrf(request)
-    if csrf_error is not None:
-        return csrf_error
-
-    # capture for audit before clearing
-    _uid = request.session.get("userId")
-    request.session.clear()
-    response = Response(status_code=204)
-    # delete session cookie
-    session_cookie = _cfg("session_cookie", "sid")
-    response.delete_cookie(session_cookie)
-    # audit log (logout)
-    try:
-        logger.info(
-            json.dumps(
-                {
-                    "event": "auth.logout",
-                    "userId": _uid,
-                    "ip": getattr(request.client, "host", None),
-                    "requestId": get_request_id(),
-                },
-                ensure_ascii=False,
-            )
-        )
-    except Exception:
-        pass
-    return response
+    return await AuthService.logout(request)
 
 
 @router.get("/session")
 async def get_session(request: Request):
-    """
-    설명: 세션 인증 상태 조회. 캐시 금지 헤더 포함.
-    갱신일: 2025-09-07
-    """
-    authed = "userId" in request.session
-    result = {"authenticated": bool(authed)}
-    if authed:
-        result.update({"userId": request.session.get("userId"), "name": request.session.get("name")})
-    resp = successResponse(result=result)
-    r = JSONResponse(content=resp, status_code=200)
-    r.headers["Cache-Control"] = "no-store"
-    return r
+    return await AuthService.get_session(request)
 
 
 @router.post("/token")
 async def issue_token(request: Request):
-    """
-    설명: 베어러 액세스 토큰 발급. 잘못된 시도에만 레이트리밋 적용.
-    갱신일: 2025-09-07
-    """
-    body = await request.json()
-    username = body.get("username")
-    password = body.get("password")
-
-    invalid = _validate_input(request, username, password)
-    if invalid is not None:
-        # align to bearer realm
-        invalid.headers = {"WWW-Authenticate": "Bearer"}
-        return invalid
-
-    await _ensure_auth_tables()
-    if "main_db" not in dbManagers:
-        loc = detect_locale(request)
-        return JSONResponse(
-            status_code=500,
-            content=errorResponse(message=i18n_t("db.unavailable", "db unavailable", loc), code="AUTH_500_DB"),
-        )
-    db = dbManagers["main_db"]
-    user = await db.fetchOne(
-        "SELECT username, password_hash, name FROM T_USER WHERE username = :u",
-        {"u": username},
-    )
-    if not user or not bcrypt.checkpw(password.encode(), user["password_hash"].encode()):
-        logger.info("auth.token.fail invalid")
-        # rate limit only on invalid creds
-        limited = _rate_limit(request, username=username)
-        if limited is not None:
-            return limited
-        return JSONResponse(
-            status_code=401,
-            content=errorResponse(message=i18n_t("error.invalid_credentials", "invalid credentials", detect_locale(request)), code="AUTH_401_INVALID"),
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    token: Token = createAccessToken({"sub": username})
-    return successResponse(
-        result={
-            "access_token": token.accessToken,
-            "token_type": token.tokenType,
-            "expires_in": token.expiresIn,
-        }
-    )
+    return await AuthService.issue_token(request)
 
 
 @router.get("/csrf")
 async def issue_csrf(request: Request):
-    """
-    설명: CSRF 토큰 발급(세션 저장). 프론트 보호용.
-    갱신일: 2025-09-07
-    """
-    csrf = uuid.uuid4().hex
-    request.session["csrf"] = csrf
-    return successResponse(result={"csrf": csrf})
+    return await AuthService.issue_csrf(request)
 
 
 @router.get("/me")
 async def me(user=Depends(getCurrentUser)):
-    """
-    설명: 베어러 토큰 검증 후 사용자 정보 반환.
-    갱신일: 2025-09-07
-    """
-    return successResponse(result={"username": user.username})
+    return await AuthService.me(user)

--- a/backend/router/ObservabilityRouter.py
+++ b/backend/router/ObservabilityRouter.py
@@ -2,115 +2,21 @@
 파일명: backend/router/ObservabilityRouter.py
 작성자: Codex CLI
 갱신일: 2025-09-07
-설명: 헬스체크·레디니스 API. 공통 규칙 준수(표준 응답/캐시 금지/요청ID).
+설명: 헬스체크 및 레디니스 라우터. 서비스 계층 호출만 수행.
 """
-
-import asyncio
-import os
-from datetime import datetime, timezone
-from typing import Dict
 
 from fastapi import APIRouter, Request
 
-from lib import Database as DB
-from lib.Response import successResponse, errorResponse
-from lib.I18n import detect_locale, t as i18n_t
-
+from service import ObservabilityService
 
 router = APIRouter(tags=["observability"])
 
 
-_started_at = datetime.now(timezone.utc)
-
-
-def _version_info() -> Dict[str, str]:
-    version = os.getenv("APP_VERSION", "dev")
-    git_sha = os.getenv("GIT_SHA", "unknown")
-    return {
-        "version": version,
-        "git_sha": git_sha,
-        "started_at": _started_at.isoformat(),
-    }
-
-
 @router.get("/healthz")
 async def healthz(request: Request):
-    """
-    설명: 서버 상태 OK 및 버전/업타임 반환. 캐시 금지.
-    갱신일: 2025-09-07
-    """
-    now = datetime.now(timezone.utc)
-    uptime_s = int((now - _started_at).total_seconds())
-    payload = {
-        "ok": True,
-        **_version_info(),
-        "uptime_s": uptime_s,
-    }
-    resp = successResponse(result=payload)
-    # headers
-    request.scope["state"] = getattr(request, "state", None)
-    # Response-level headers will be added by middleware for request id
-    from fastapi.responses import JSONResponse
-
-    response = JSONResponse(content=resp, status_code=200)
-    response.headers["Cache-Control"] = "no-store"
-    return response
+    return await ObservabilityService.healthz(request)
 
 
 @router.get("/readyz")
 async def readyz(request: Request):
-    """
-    설명: DB 핑 포함 레디니스 점검. 타임아웃·메인터넌스 모드 반영.
-    갱신일: 2025-09-07
-    """
-    # maintenance override
-    maintenance = os.getenv("MAINTENANCE_MODE", "false").lower() in ("1", "true", "yes")
-    checks: Dict[str, str] = {}
-    ok = True
-
-    if maintenance:
-        ok = False
-    else:
-        # DB ping: check all registered databases, but report primary 'main_db' if present
-        try:
-            # prefer main_db if exists, else ping any one
-            targets = ["main_db"] if "main_db" in DB.dbManagers else list(DB.dbManagers.keys())
-            if not targets:
-                # no DB configured – consider up by design
-                checks["db"] = "up"
-            else:
-                for name in targets:
-                    # choose dialect-specific lightweight query
-                    mgr = DB.dbManagers[name]
-                    url = getattr(mgr, "databaseUrl", "") or ""
-                    if "oracle" in url:
-                        ping_sql = "SELECT 1 FROM DUAL"
-                    else:
-                        ping_sql = "SELECT 1"
-                    try:
-                        # enforce timeout (default 300ms)
-                        timeout_ms = int(os.getenv("READYZ_TIMEOUT_MS", "300"))
-                        await asyncio.wait_for(mgr.fetchOne(ping_sql), timeout=timeout_ms / 1000.0)
-                        checks["db"] = "up"
-                    except Exception:
-                        checks["db"] = "down"
-                        ok = False
-                        break
-        except Exception:
-            checks["db"] = "down"
-            ok = False
-
-    status_code = 200 if ok else 503
-
-    payload = {"ok": ok, **checks}
-    from fastapi.responses import JSONResponse
-    from lib.Response import errorResponse
-
-    if ok:
-        resp = successResponse(result=payload)
-    else:
-        loc = detect_locale(request)
-        resp = errorResponse(message=i18n_t("obs.not_ready", "not ready", loc), result=payload, code="OBS_503_NOT_READY")
-    response = JSONResponse(content=resp, status_code=status_code)
-    response.headers["Cache-Control"] = "no-store"
-    return response
+    return await ObservabilityService.readyz(request)

--- a/backend/service/AuthService.py
+++ b/backend/service/AuthService.py
@@ -1,0 +1,288 @@
+"""
+파일: backend/service/AuthService.py
+작성: Codex CLI
+설명: 인증 도메인 서비스. 라우터에서 호출되어 로그인/로그아웃/토큰 발급 등 처리.
+"""
+
+import os
+import json
+import time
+import uuid
+from collections import deque
+from typing import Optional
+
+import bcrypt
+from fastapi import Request
+from fastapi.responses import JSONResponse, Response
+
+from lib.Auth import AuthConfig, Token, createAccessToken
+from lib.Database import dbManagers
+from lib.Response import errorResponse, successResponse
+from lib.Logger import logger
+from lib.I18n import detect_locale, t as i18n_t
+from lib.RequestContext import get_request_id
+
+
+def _cfg(key: str, default: Optional[str] = None) -> str:
+    try:
+        from .. import server as server_mod  # when imported as package
+    except Exception:  # pragma: no cover
+        import server as server_mod  # when running as module from backend/
+    section = server_mod.config["AUTH"]
+    return section.get(key, default) if default is not None else section[key]
+
+
+# Simple in-memory rate limiter (per-process)
+class _RateLimiter:
+    def __init__(self, limit: int = 5, window_sec: int = 60):
+        self.limit = limit
+        self.window = window_sec
+        self.store = {}
+
+    def _now(self):
+        return time.monotonic()
+
+    def hit(self, key: str):
+        now = self._now()
+        dq = self.store.get(key)
+        if dq is None:
+            dq = deque()
+            self.store[key] = dq
+        # drop old
+        while dq and now - dq[0] > self.window:
+            dq.popleft()
+        if len(dq) >= self.limit:
+            # seconds until reset
+            retry_after = max(1, int(self.window - (now - dq[0])))
+            return False, retry_after
+        dq.append(now)
+        return True, 0
+
+
+_rl = _RateLimiter(limit=int(os.getenv("AUTH_RATE_LIMIT", "5")), window_sec=60)
+
+
+def _rate_limit(request: Request, username: Optional[str] = None) -> Optional[Response]:
+    ip = getattr(request.client, "host", "unknown")
+    keys = [f"ip:{ip}"]
+    if username:
+        keys.append(f"user:{username}")
+    for k in keys:
+        ok, retry_after = _rl.hit(k)
+        if not ok:
+            return JSONResponse(
+                status_code=429,
+                content=errorResponse(
+                    message="too many requests", code="AUTH_429_RATE_LIMIT"
+                ),
+                headers={"Retry-After": str(retry_after)},
+            )
+    return None
+
+
+async def _ensure_auth_tables():
+    if "main_db" not in dbManagers:
+        return
+    db = dbManagers["main_db"]
+    await db.executeQuery("auth.ensureUserTable")
+    # seed demo account if absent
+    row = await db.fetchOneQuery("user.selectByUsername", {"u": "demo"})
+    if not row:
+        hashed = bcrypt.hashpw(b"password123", bcrypt.gensalt()).decode()
+        await db.executeQuery(
+            "auth.insertDemoUser",
+            {"u": "demo", "p": hashed, "n": "Demo User", "e": "demo@example.com", "r": "admin"},
+        )
+
+
+def _validate_input(request: Request, username: str, password: str) -> Optional[Response]:
+    loc = detect_locale(request)
+    if not isinstance(username, str) or not isinstance(password, str):
+        return JSONResponse(
+            status_code=422,
+            content=errorResponse(
+                message=i18n_t("error.invalid_input", "invalid input", loc), result=None, code="AUTH_422_INVALID_INPUT"
+            ),
+            headers={"WWW-Authenticate": "Cookie"},
+        )
+    if len(username) < 3 or len(password) < 8:
+        return JSONResponse(
+            status_code=422,
+            content=errorResponse(
+                message=i18n_t("error.invalid_input", "invalid input", loc), result=None, code="AUTH_422_INVALID_INPUT"
+            ),
+            headers={"WWW-Authenticate": "Cookie"},
+        )
+    return None
+
+
+def _require_csrf(request: Request) -> Optional[Response]:
+    header_name = _cfg("csrf_header", "X-CSRF-Token")
+    expected = request.session.get("csrf")
+    provided = request.headers.get(header_name)
+    if not expected or not provided or expected != provided:
+        return JSONResponse(
+            status_code=403,
+            content=errorResponse(
+                message=i18n_t("error.csrf_required", "csrf required", detect_locale(request)), result=None, code="AUTH_403_CSRF_REQUIRED"
+            ),
+            headers={"WWW-Authenticate": "Cookie"},
+        )
+    return None
+
+
+async def login(request: Request):
+    await _ensure_auth_tables()
+    body = await request.json()
+    username = body.get("username")
+    password = body.get("password")
+    remember = bool(body.get("rememberMe", False))
+
+    invalid = _validate_input(request, username, password)
+    if invalid is not None:
+        return invalid
+
+    if "main_db" not in dbManagers:
+        loc = detect_locale(request)
+        return JSONResponse(
+            status_code=500,
+            content=errorResponse(message=i18n_t("db.unavailable", "db unavailable", loc), code="AUTH_500_DB"),
+        )
+    db = dbManagers["main_db"]
+    user = await db.fetchOneQuery("user.selectByUsername", {"u": username})
+    if not user:
+        logger.info("auth.login.fail username")
+        limited = _rate_limit(request, username=username)
+        if limited is not None:
+            return limited
+        return JSONResponse(
+            status_code=401,
+            content=errorResponse(message=i18n_t("error.invalid_credentials", "invalid credentials", detect_locale(request)), code="AUTH_401_INVALID"),
+            headers={"WWW-Authenticate": "Cookie"},
+        )
+    if not bcrypt.checkpw(password.encode(), user["password_hash"].encode()):
+        logger.info("auth.login.fail password")
+        limited = _rate_limit(request, username=username)
+        if limited is not None:
+            return limited
+        return JSONResponse(
+            status_code=401,
+            content=errorResponse(message=i18n_t("error.invalid_credentials", "invalid credentials", detect_locale(request)), code="AUTH_401_INVALID"),
+            headers={"WWW-Authenticate": "Cookie"},
+        )
+
+    # rotate session by clearing and setting new data
+    request.session.clear()
+    request.session["userId"] = user["username"]
+    request.session["name"] = user.get("name") or None
+    # issue csrf
+    csrf = uuid.uuid4().hex
+    request.session["csrf"] = csrf
+
+    response = Response(status_code=204)
+    # audit log (success)
+    try:
+        logger.info(
+            json.dumps(
+                {
+                    "event": "auth.login.success",
+                    "userId": user["username"],
+                    "ip": getattr(request.client, "host", None),
+                    "requestId": get_request_id(),
+                },
+                ensure_ascii=False,
+            )
+        )
+    except Exception:
+        pass
+    if remember:
+        response.set_cookie("rememberMe", "1", max_age=60 * 60 * 24 * 30, httponly=False)
+    return response
+
+
+async def logout(request: Request):
+    csrf_error = _require_csrf(request)
+    if csrf_error is not None:
+        return csrf_error
+
+    _uid = request.session.get("userId")
+    request.session.clear()
+    response = Response(status_code=204)
+    session_cookie = _cfg("session_cookie", "sid")
+    response.delete_cookie(session_cookie)
+    try:
+        logger.info(
+            json.dumps(
+                {
+                    "event": "auth.logout",
+                    "userId": _uid,
+                    "ip": getattr(request.client, "host", None),
+                    "requestId": get_request_id(),
+                },
+                ensure_ascii=False,
+            )
+        )
+    except Exception:
+        pass
+    return response
+
+
+async def get_session(request: Request):
+    authed = "userId" in request.session
+    result = {"authenticated": bool(authed)}
+    if authed:
+        result.update({"userId": request.session.get("userId"), "name": request.session.get("name")})
+    resp = successResponse(result=result)
+    r = JSONResponse(content=resp, status_code=200)
+    r.headers["Cache-Control"] = "no-store"
+    return r
+
+
+async def issue_token(request: Request):
+    body = await request.json()
+    username = body.get("username")
+    password = body.get("password")
+
+    invalid = _validate_input(request, username, password)
+    if invalid is not None:
+        invalid.headers = {"WWW-Authenticate": "Bearer"}
+        return invalid
+
+    await _ensure_auth_tables()
+    if "main_db" not in dbManagers:
+        loc = detect_locale(request)
+        return JSONResponse(
+            status_code=500,
+            content=errorResponse(message=i18n_t("db.unavailable", "db unavailable", loc), code="AUTH_500_DB"),
+        )
+    db = dbManagers["main_db"]
+    user = await db.fetchOneQuery("user.selectByUsername", {"u": username})
+    if not user or not bcrypt.checkpw(password.encode(), user["password_hash"].encode()):
+        logger.info("auth.token.fail invalid")
+        limited = _rate_limit(request, username=username)
+        if limited is not None:
+            return limited
+        return JSONResponse(
+            status_code=401,
+            content=errorResponse(message=i18n_t("error.invalid_credentials", "invalid credentials", detect_locale(request)), code="AUTH_401_INVALID"),
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    token: Token = createAccessToken({"sub": username})
+    return successResponse(
+        result={
+            "access_token": token.accessToken,
+            "token_type": token.tokenType,
+            "expires_in": token.expiresIn,
+        }
+    )
+
+
+async def issue_csrf(request: Request):
+    csrf = uuid.uuid4().hex
+    request.session["csrf"] = csrf
+    return successResponse(result={"csrf": csrf})
+
+
+async def me(user):
+    return successResponse(result={"username": user.username})

--- a/backend/service/ObservabilityService.py
+++ b/backend/service/ObservabilityService.py
@@ -1,0 +1,94 @@
+"""
+파일: backend/service/ObservabilityService.py
+작성: Codex CLI
+설명: 헬스체크 및 레디니스 서비스 로직.
+"""
+
+import asyncio
+import os
+from datetime import datetime, timezone
+from typing import Dict
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+from lib import Database as DB
+from lib.Response import successResponse, errorResponse
+from lib.I18n import detect_locale, t as i18n_t
+
+_started_at = datetime.now(timezone.utc)
+
+
+def _version_info() -> Dict[str, str]:
+    version = os.getenv("APP_VERSION", "dev")
+    git_sha = os.getenv("GIT_SHA", "unknown")
+    return {
+        "version": version,
+        "git_sha": git_sha,
+        "started_at": _started_at.isoformat(),
+    }
+
+
+async def healthz(request: Request):
+    now = datetime.now(timezone.utc)
+    uptime_s = int((now - _started_at).total_seconds())
+    payload = {
+        "ok": True,
+        **_version_info(),
+        "uptime_s": uptime_s,
+    }
+    resp = successResponse(result=payload)
+    request.scope["state"] = getattr(request, "state", None)
+    response = JSONResponse(content=resp, status_code=200)
+    response.headers["Cache-Control"] = "no-store"
+    return response
+
+
+async def readyz(request: Request):
+    maintenance = os.getenv("MAINTENANCE_MODE", "false").lower() in ("1", "true", "yes")
+    checks: Dict[str, str] = {}
+    ok = True
+
+    if maintenance:
+        ok = False
+    else:
+        try:
+            targets = ["main_db"] if "main_db" in DB.dbManagers else list(DB.dbManagers.keys())
+            if not targets:
+                checks["db"] = "up"
+            else:
+                for name in targets:
+                    mgr = DB.dbManagers[name]
+                    url = getattr(mgr, "databaseUrl", "") or ""
+                    if "oracle" in url:
+                        query_name = "sys.oraclePing"
+                        fallback_sql = "SELECT 1 FROM DUAL"
+                    else:
+                        query_name = "sys.ping"
+                        fallback_sql = "SELECT 1"
+                    try:
+                        timeout_ms = int(os.getenv("READYZ_TIMEOUT_MS", "300"))
+                        if hasattr(mgr, "queryManager"):
+                            sql = mgr.queryManager.getQuery(query_name) or fallback_sql
+                        else:
+                            sql = fallback_sql
+                        await asyncio.wait_for(mgr.fetchOne(sql), timeout=timeout_ms / 1000.0)
+                        checks["db"] = "up"
+                    except Exception:
+                        checks["db"] = "down"
+                        ok = False
+                        break
+        except Exception:
+            checks["db"] = "down"
+            ok = False
+
+    status_code = 200 if ok else 503
+    payload = {"ok": ok, **checks}
+    if ok:
+        resp = successResponse(result=payload)
+    else:
+        loc = detect_locale(request)
+        resp = errorResponse(message=i18n_t("obs.not_ready", "not ready", loc), result=payload, code="OBS_503_NOT_READY")
+    response = JSONResponse(content=resp, status_code=status_code)
+    response.headers["Cache-Control"] = "no-store"
+    return response

--- a/backend/service/TransactionService.py
+++ b/backend/service/TransactionService.py
@@ -14,25 +14,20 @@ async def ensure_tables() -> None:
     if "main_db" not in DB.dbManagers:
         return
     db = DB.dbManagers["main_db"]
-    await db.execute("""
-    CREATE TABLE IF NOT EXISTS test_transaction (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        value TEXT UNIQUE
-    )
-    """)
+    await db.executeQuery("tx.ensureTable")
 
 
 async def do_single_commit() -> None:
     await ensure_tables()
     db = DB.dbManagers["main_db"]
-    await db.execute("INSERT INTO test_transaction (value) VALUES (:val)", {"val": "tx-single"})
+    await db.executeQuery("tx.insertValue", {"val": "tx-single"})
 
 
 async def do_unique_violation() -> None:
     await ensure_tables()
     db = DB.dbManagers["main_db"]
     # insert a fixed value to hit unique constraint
-    await db.execute("INSERT INTO test_transaction (value) VALUES (:val)", {"val": "tx-dup"})
+    await db.executeQuery("tx.insertValue", {"val": "tx-dup"})
     # second insert will violate UNIQUE
-    await db.execute("INSERT INTO test_transaction (value) VALUES (:val)", {"val": "tx-dup"})
+    await db.executeQuery("tx.insertValue", {"val": "tx-dup"})
 


### PR DESCRIPTION
## Summary
- separate backend flows into router->service->query
- add SQL files for auth and transaction queries
- clean routers to delegate logic to services only

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd7528dee0832080b62402cf5a5fc0