### PR TITLE
docs: sync web specs with current frontend

### DIFF
--- a/docs/modules/web.md
+++ b/docs/modules/web.md
@@ -22,19 +22,20 @@
 - CU-WEB-006 SSR/CSR Runtime Switch
 - CU-WEB-007 Migration (Vite→Next)
 - CU-WEB-008 Middleware Guard & Redirect
+- CU-WEB-009 Data Fetch Strategy (SSR/CSR 전환)
 
 ## 진행 현황(Units)
-- CU-WEB-001 Auth & Login Page: draft — Vite 로그인 화면 존재, 백엔드 API 연동/검증·오류 UX 보완 필요
+- CU-WEB-001 Auth & Login Page: in-progress — Next 로그인 페이지에서 SSR/CSR 세션 확인 구현, 오류 UX·A11y 보완 필요
 - CU-WEB-002 Dashboard: planned — 카드/리스트/통계 위젯 구성 예정
 - CU-WEB-003 UI Component Pack: in-progress — 핵심 입력/피드백 컴포넌트 보유, Next 환경 데이터 바인딩 규약 정리 필요
-- CU-WEB-004 Routing & Guard: planned — 보호 라우트/리다이렉트 상태 관리 설계 필요
-- CU-WEB-005 API Client: planned — OpenAPI 스키마 연계(JS 클라이언트: openapi-client-axios) 미구성
+- CU-WEB-004 Routing & Guard: in-progress — 미들웨어·서버 레이아웃으로 기본 리다이렉트 구현, next 파라미터·401 핸들링 보완 필요
+- CU-WEB-005 API Client: in-progress — ssrJSON/csrJSON 헬퍼와 CSRF 주입 존재, OpenAPI 클라이언트 연계 미구성
 - CU-WEB-006 SSR/CSR Runtime Switch: planned — ENV + 페이지 export 기반 전환 헬퍼 구현 필요
 - CU-WEB-007 Migration: in-progress — 컴포넌트/페이지 구조 이전 계획 수립
-- CU-WEB-008 Middleware Guard & Redirect: planned — 경로 보호/리디렉션 규칙 정의
+- CU-WEB-008 Middleware Guard & Redirect: in-progress — middleware.js로 쿠키 기반 리다이렉트 구현, 경로 화이트리스트·next 검증 보완 필요
+- CU-WEB-009 Data Fetch Strategy: in-progress — initData와 runtime fetch 헬퍼 도입, 공통 데이터 계약 정립 필요
 
 ## TODO
-- Next 템플릿 스캐폴딩: frontend-web 생성(App Router/Tailwind v4)
 - Auth 연동: 로그인→백엔드 로그인 API 연결(성공/실패 토스트, 302 리다이렉트)
 - 보호 라우트: 서버 설정과 클라이언트 세션 모두 반영(미인증 즉시 /login)
 - 대시보드: 카드/리스트/통계 위젯 구성, 반응형 레이아웃

--- a/docs/units/web/CU-WEB-001.md
+++ b/docs/units/web/CU-WEB-001.md
@@ -2,7 +2,7 @@
 id: CU-WEB-001
 name: Auth & Login Page
 module: web
-status: draft
+status: in-progress
 priority: P1
 links: [CU-BE-001, CU-WEB-004, CU-WEB-005, CU-WEB-008]
 ---
@@ -71,3 +71,7 @@ links: [CU-BE-001, CU-WEB-004, CU-WEB-005, CU-WEB-008]
 - ENV: `NEXT_PUBLIC_API_BASE`
 - 기본 runtime은 nodejs(쿠키 접근), 경로에 따라 edge 선택 가능
 - UI 바인딩(EasyObj): value/onChange 규약 준수, 폼모델과 EasyObj 연결(SWR와 충돌 없게 분리)
+
+### Implementation Notes
+- `frontend-web/app/login`은 SSR `ssrJSON`으로 세션을 확인하고 `SharedHydrator`로 상태를 초기화한다.
+- 로그인 요청은 `postWithCsrf`로 처리하며, 미구현된 오류 UX·A11y는 후속 보완이 필요하다.

--- a/docs/units/web/CU-WEB-004.md
+++ b/docs/units/web/CU-WEB-004.md
@@ -2,7 +2,7 @@
 id: CU-WEB-004
 name: Routing & Guard (Protected Routes)
 module: web
-status: planned
+status: in-progress
 priority: P1
 links: [CU-WEB-001, CU-WEB-002, CU-WEB-005, CU-WEB-006, CU-WEB-008, CU-BE-001]
 ---
@@ -75,6 +75,5 @@ links: [CU-WEB-001, CU-WEB-002, CU-WEB-005, CU-WEB-006, CU-WEB-008, CU-BE-001]
 - ë ˆì´ì•„ì›ƒ/ëª…ì¹­ ë ˆì´ì–´: `frontend-web` ì¼ê´€ ìœ ì§€
 
 ### Implementation Notes
-- Route Group (protected)¸¦ »ç¿ëÇØ ±×·ì ·¹ÀÌ¾Æ¿ô¿¡¼­ SSR °¡µå¸¦ Àû¿ëÇÑ´Ù(°æ·Î¿¡´Â ³ëÃâµÇÁö ¾ÊÀ½).
-- per?page ÃÊ±â ¿£µåÆ÷ÀÎÆ®: pp/(protected)/initData.jsx¿¡ SESSION_PATH Á¤ÀÇ.
-- SSR °¡µå: ·¹ÀÌ¾Æ¿ô¿¡¼­ ssrJSON(SESSION_PATH)·Î ¼¼¼Ç È®ÀÎ ÈÄ ¹ÌÀÎÁõÀº /loginÀ¸·Î redirect.
+- `frontend-web/middleware.js`ì—ì„œ `sid` ì¿ í‚¤ê°€ ì—†ìœ¼ë©´ `/login`ìœ¼ë¡œ 302 ë¦¬ë‹¤ì´ë ‰íŠ¸í•œë‹¤.
+- `app/(protected)/layout.jsx`ëŠ” `ssrJSON(SESSION_PATH)`ë¡œ ì„¸ì…˜ì„ í™•ì¸í•˜ê³  ë¯¸ì¸ì¦ ì‹œ `redirect('/login')`ì„ í˜¸ì¶œí•œë‹¤.

--- a/docs/units/web/CU-WEB-005.md
+++ b/docs/units/web/CU-WEB-005.md
@@ -2,7 +2,7 @@
 id: CU-WEB-005
 name: API Client (OpenAPI JS ì—°ë™)
 module: web
-status: planned
+status: in-progress
 priority: P1
 links: [CU-BE-001, CU-BE-005, CU-WEB-001, CU-WEB-004, CU-WEB-006]
 ---
@@ -81,5 +81,5 @@ links: [CU-BE-001, CU-BE-005, CU-WEB-001, CU-WEB-004, CU-WEB-006]
 - í˜¸ì¶œ ê·œì•½: SWR ì˜ì—­ê³¼ credentials:'include' ê°•ì œ, ë¹„ë©±ë“± CSRF í•„ìˆ˜
 
 ### Implementation Notes
-- ÇöÀç´Â ·±Å¸ÀÓ À¯Æ¿(ssrJSON/csrJSON)·Î SSR/CSR È£Ãâ ±Ô¾àÀ» ÅëÀÏÇÏ¿© »ç¿ë Áß.
-- openapi-client-axios´Â ÃßÈÄ ÀÎÅÍ¼ÁÅÍ(401/403/422, CSRF ÀÚµ¿ ÁÖÀÔ)·Î ·¡ÇÎÇØ ±³Ã¼/ÅëÇÕ ¿¹Á¤.
+- `app/lib/runtime/ssr.jsx`ì™€ `csr.jsx`ì— ê¸°ë³¸ fetch ë˜í¼ì™€ `postWithCsrf`ê°€ êµ¬í˜„ë˜ì–´ ìˆë‹¤.
+- OpenAPI í´ë¼ì´ì–¸íŠ¸(openapi-client-axios) ì—°ë™ê³¼ ì˜¤ë¥˜ ë§µí•‘ì€ ì•„ì§ ë¯¸êµ¬ì„± ìƒíƒœë‹¤.

--- a/docs/units/web/CU-WEB-008.md
+++ b/docs/units/web/CU-WEB-008.md
@@ -2,7 +2,7 @@
 id: CU-WEB-008
 name: Middleware Guard & Redirect
 module: web
-status: planned
+status: in-progress
 priority: P1
 links: [CU-WEB-001, CU-WEB-004, CU-WEB-005, CU-WEB-006, CU-WEB-002, CU-BE-001]
 ---
@@ -67,3 +67,7 @@ links: [CU-WEB-001, CU-WEB-004, CU-WEB-005, CU-WEB-006, CU-WEB-002, CU-BE-001]
 - 체인 정합: 미들웨어는 존재 판정만, 서버 가드는 검증/리다이렉트, 클라는 만료 대응
 - 백엔드 연동: `/api/v1/auth/*` 표준 응답/쿠키 정책(CU-BE-001)과 1:1 정합
 - 문서 정합: index.md / web.md / backend.md의 경로·쿠키·CSRF 규약과 일치
+
+### Implementation Notes
+- `frontend-web/middleware.js`는 보호 경로에서 `sid` 쿠키를 검사해 없으면 `/login`으로 302 리다이렉트한다.
+- 공개/보호 경로 패턴과 `next` 검증 로직은 향후 확장이 필요하다.

--- a/docs/units/web/CU-WEB-009_data-fetch-strategy.md
+++ b/docs/units/web/CU-WEB-009_data-fetch-strategy.md
@@ -2,7 +2,7 @@
 id: CU-WEB-009
 name: Data Fetch Strategy (SSR/CSR 전환)
 module: web
-status: planned
+status: in-progress
 priority: P1
 links: [CU-WEB-001, CU-WEB-002, CU-WEB-004, CU-WEB-005, CU-WEB-006, CU-WEB-008, CU-BE-001]
 ---
@@ -37,6 +37,9 @@ links: [CU-WEB-001, CU-WEB-002, CU-WEB-004, CU-WEB-005, CU-WEB-006, CU-WEB-008, 
 - 페이지별 MODE 전환만으로 SSR→CSR가 동작하고, SSR 경로에서 SEO(HTML/메타)가 반영된다.
 - 공통 계약을 통해 SSR/CSR 모두 응답 규약과 에러 처리(401→/login, 403→CSRF 안내)가 일관되게 동작한다.
 - 보호 페이지는 기본 SSR(nodejs, no-store)이며, 무거운 위젯은 CSR로 분리해 깜빡임 없이 렌더링된다.
+
+### Implementation Notes
+- `app/login`과 `(protected)` 페이지는 `initData.jsx`와 `ssrJSON/csrJSON` 헬퍼를 사용해 SSR/CSR 전환 패턴을 시범 구현한다.
 
 ### Tasks
 - 공통 계약 파일(data/fetch.js) 정의(최소: 세션/프로필/리스트 등).


### PR DESCRIPTION
## Summary
- update web module progress and add data fetch unit
- mark login, guard, API client docs as in-progress with implementation notes
- document middleware guard and SSR/CSR fetch pattern in units

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be8d145dcc832096437a204cf73431