### PR TITLE
fix: correct encoding in input examples

### DIFF
--- a/frontend-web/app/component/docs/examples/InputExamples.jsx
+++ b/frontend-web/app/component/docs/examples/InputExamples.jsx
@@ -11,13 +11,13 @@ export const InputExamples = () => {
             component: <Lib.Input
                 dataObj={dataObj}
                 dataKey="basicInput"
-                placeholder="?�스?��? ?�력?�세??
+                placeholder="텍스트 입력하세요"
             />,
-            description: "기본 ?�력",
+            description: "기본 입력",
             code: `<Lib.Input
     dataObj={dataObj}
     dataKey="basicInput"
-    placeholder="?�스?��? ?�력?�세??
+    placeholder="텍스트 입력하세요"
 />`
         },
         {
@@ -25,14 +25,14 @@ export const InputExamples = () => {
                 dataObj={dataObj}
                 dataKey="email"
                 type="email"
-                placeholder="?�메?�을 ?�력?�세??
+                placeholder="이메일을 입력하세요"
             />,
-            description: "?�메???�력",
+            description: "이메일 입력",
             code: `<Lib.Input
     dataObj={dataObj}
     dataKey="email"
     type="email"
-    placeholder="?�메?�을 ?�력?�세??
+    placeholder="이메일을 입력하세요"
 />`
         },
         {
@@ -40,14 +40,14 @@ export const InputExamples = () => {
                 dataObj={dataObj}
                 dataKey="phone"
                 mask="###-####-####"
-                placeholder="?�화번호: 010-1234-5678"
+                placeholder="전화번호: 010-1234-5678"
             />,
-            description: "?�화번호 마스??,
+            description: "전화번호 마스킹",
             code: `<Lib.Input
     dataObj={dataObj}
     dataKey="phone"
     mask="###-####-####"
-    placeholder="?�화번호: 010-1234-5678"
+    placeholder="전화번호: 010-1234-5678"
 />`
         },
         {
@@ -55,14 +55,14 @@ export const InputExamples = () => {
                 dataObj={dataObj}
                 dataKey="businessNo"
                 mask="###-##-#####"
-                placeholder="?�업?�번?? 123-45-67890"
+                placeholder="사업자번호 123-45-67890"
             />,
-            description: "?�업?�번??마스??,
+            description: "사업자번호 마스킹",
             code: `<Lib.Input
     dataObj={dataObj}
     dataKey="businessNo"
     mask="###-##-#####"
-    placeholder="?�업?�번?? 123-45-67890"
+    placeholder="사업자번호 123-45-67890"
 />`
         },
         {
@@ -72,16 +72,16 @@ export const InputExamples = () => {
                 type="number"
                 maxDigits={10}
                 maxDecimals={2}
-                placeholder="?�자�??�력 (최�? 10?�리, ?�수??2?�리)"
+                placeholder="숫자 입력 (최대 10자리, 소수점2자리)"
             />,
-            description: "?�자 ?�력 (?�릿???�한)",
+            description: "숫자 입력 (자리수 제한)",
             code: `<Lib.Input
     dataObj={dataObj}
     dataKey="amount"
     type="number"
     maxDigits={10}
     maxDecimals={2}
-    placeholder="?�자�??�력 (최�? 10?�리, ?�수??2?�리)"
+    placeholder="숫자 입력 (최대 10자리, 소수점2자리)"
 />`
         },
         {
@@ -89,44 +89,44 @@ export const InputExamples = () => {
                 dataObj={dataObj}
                 dataKey="code"
                 filter="A-Za-z0-9"
-                placeholder="?�문�??�자�??�력"
+                placeholder="영문/숫자 입력"
             />,
-            description: "?�문/?�자 ?�터",
+            description: "영문/숫자 필터",
             code: `<Lib.Input
     dataObj={dataObj}
     dataKey="code"
     filter="A-Za-z0-9"
-    placeholder="?�문�??�자�??�력"
+    placeholder="영문/숫자 입력"
 />`
         },
         {
             component: <Lib.Input
                 dataObj={dataObj}
                 dataKey="koreanName"
-                filter="가-??
-                placeholder="?��?�??�력"
+                filter="가-힣"
+                placeholder="한글 입력"
             />,
-            description: "?��? ?�터",
+            description: "한글 필터",
             code: `<Lib.Input
     dataObj={dataObj}
     dataKey="koreanName"
-    filter="가-??
-    placeholder="?��?�??�력"
+    filter="가-힣"
+    placeholder="한글 입력"
 />`
         },
         {
             component: <Lib.Input
                 dataObj={dataObj}
                 dataKey="email"
-                error="?�메???�식???�바르�? ?�습?�다"
-                placeholder="?�러 ?�태 ?�시"
+                error="이메일 형식이 올바르지 않습니다"
+                placeholder="에러 상태 표시"
             />,
-            description: "?�러 ?�태",
+            description: "에러 상태",
             code: `<Lib.Input
     dataObj={dataObj}
     dataKey="email"
-    error="?�메???�식???�바르�? ?�습?�다"
-    placeholder="?�러 ?�태 ?�시"
+    error="이메일 형식이 올바르지 않습니다"
+    placeholder="에러 상태 표시"
 />`
         },
         {
@@ -136,18 +136,18 @@ export const InputExamples = () => {
                 type="number"
                 maxDigits={10}
                 className="text-right"
-                placeholder="금액 ?�력"
-                suffix="??
+                placeholder="금액 입력"
+                suffix="원"
             />,
-            description: "금액 ?�력 (?�측 ?�렬, ?�위 ?�시)",
+            description: "금액 입력 (우측 정렬, 접미사 표시)",
             code: `<Lib.Input
     dataObj={dataObj}
     dataKey="price"
     type="number"
     maxDigits={10}
     className="text-right"
-    placeholder="금액 ?�력"
-    suffix="??
+    placeholder="금액 입력"
+    suffix="원"
 />`
         },
         {
@@ -155,14 +155,14 @@ export const InputExamples = () => {
                 dataObj={dataObj}
                 dataKey="searchKeyword"
                 prefix={<Lib.Icon icon="ri:RiSearchLine" className="w-5 h-5 text-gray-400" />}
-                placeholder="검?�어�??�력?�세??
+                placeholder="검색어를 입력하세요"
             />,
-            description: "?�이콘이 ?�는 검???�력",
+            description: "아이콘이 있는 검색 입력",
             code: `<Lib.Input
     dataObj={dataObj}
     dataKey="searchKeyword"
     prefix={<Lib.Icon icon="ri:RiSearchLine" className="w-5 h-5 text-gray-400" />}
-    placeholder="검?�어�??�력?�세??
+    placeholder="검색어를 입력하세요"
 />`
         },
         {
@@ -170,20 +170,20 @@ export const InputExamples = () => {
                 dataObj={dataObj}
                 dataKey="password"
                 type="password"
-                placeholder="비�?번호 ?�력"
+                placeholder="비밀번호 입력"
                 togglePassword={true}
             />,
-            description: "비�?번호 ?��? 기능",
+            description: "비밀번호 토글 기능",
             code: `<Lib.Input
     dataObj={dataObj}
     dataKey="password"
     type="password"
-    placeholder="비�?번호 ?�력"
+    placeholder="비밀번호 입력"
     togglePassword={true}
 />`
         }
     ];
 
     return examples;
-}; 
+};
 


### PR DESCRIPTION
## Summary
- fix corrupted Korean placeholders in InputExamples docs
- ensure numeric and price input examples render correctly with suffix

## Testing
- `npm run lint`
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_68bec08bc68c832087d54a3193421039