### PR TITLE
docs: expand slider examples and restore original component

### DIFF
--- a/frontend-web/app/component/docs/components/SliderDocs.jsx
+++ b/frontend-web/app/component/docs/components/SliderDocs.jsx
@@ -22,6 +22,38 @@ const SliderDocs = () => {
           <CodeBlock code={examples[1]?.code || ''} />
         </div>
       </div>
+      <div id="slider-top" className="mb-8">
+        <h3 className="text-lg font-medium mb-4">위쪽</h3>
+        <div>
+          {examples[2]?.component}
+          <div className="mt-2 text-sm text-gray-600">{examples[2]?.description}</div>
+          <CodeBlock code={examples[2]?.code || ''} />
+        </div>
+      </div>
+      <div id="slider-bottom" className="mb-8">
+        <h3 className="text-lg font-medium mb-4">아래쪽</h3>
+        <div>
+          {examples[3]?.component}
+          <div className="mt-2 text-sm text-gray-600">{examples[3]?.description}</div>
+          <CodeBlock code={examples[3]?.code || ''} />
+        </div>
+      </div>
+      <div id="slider-card" className="mb-8">
+        <h3 className="text-lg font-medium mb-4">카드 샘플</h3>
+        <div>
+          {examples[4]?.component}
+          <div className="mt-2 text-sm text-gray-600">{examples[4]?.description}</div>
+          <CodeBlock code={examples[4]?.code || ''} />
+        </div>
+      </div>
+      <div id="slider-menu" className="mb-8">
+        <h3 className="text-lg font-medium mb-4">메뉴 샘플</h3>
+        <div>
+          {examples[5]?.component}
+          <div className="mt-2 text-sm text-gray-600">{examples[5]?.description}</div>
+          <CodeBlock code={examples[5]?.code || ''} />
+        </div>
+      </div>
     </DocSection>
   );
 };

--- a/frontend-web/app/component/docs/examples/SliderExamples.jsx
+++ b/frontend-web/app/component/docs/examples/SliderExamples.jsx
@@ -4,35 +4,103 @@ import { useState } from 'react';
 export const SliderExamples = () => {
   const [rightOpen, setRightOpen] = useState(false);
   const [leftOpen, setLeftOpen] = useState(false);
+  const [topOpen, setTopOpen] = useState(false);
+  const [bottomOpen, setBottomOpen] = useState(false);
+  const [cardOpen, setCardOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   const examples = [
     {
       component: (
         <div>
-          <Lib.Button onClick={() => setRightOpen(true)}>오른쪽 슬라이더</Lib.Button>
+          <Lib.Button onClick={() => setRightOpen(true)}>오른쪽 빈 슬라이더</Lib.Button>
           <Lib.Slider isOpen={rightOpen} onClose={() => setRightOpen(false)} side="right">
-            <div className="h-full flex flex-col">
-              <div className="p-4 border-b font-medium">제목</div>
-              <div className="flex-1 p-4 overflow-auto">내용 영역</div>
-              <div className="p-3 border-t text-right"><Lib.Button onClick={() => setRightOpen(false)}>닫기</Lib.Button></div>
+            <div className="p-3 text-right">
+              <Lib.Button onClick={() => setRightOpen(false)}>닫기</Lib.Button>
             </div>
           </Lib.Slider>
         </div>
       ),
-      description: '기본(right) 슬라이더',
-      code: `<Lib.Slider isOpen={open} onClose={close} side="right">...</Lib.Slider>`
+      description: '오른쪽에서 열리는 빈 슬라이더',
+      code: `<Lib.Slider isOpen={open} onClose={close} side="right"><div className="p-3 text-right"><Lib.Button onClick={close}>닫기</Lib.Button></div></Lib.Slider>`
     },
     {
       component: (
         <div>
-          <Lib.Button onClick={() => setLeftOpen(true)}>왼쪽 슬라이더</Lib.Button>
+          <Lib.Button onClick={() => setLeftOpen(true)}>왼쪽 빈 슬라이더</Lib.Button>
           <Lib.Slider isOpen={leftOpen} onClose={() => setLeftOpen(false)} side="left">
-            <div className="h-full p-4">왼쪽에서 열림</div>
+            <div className="p-3 text-right">
+              <Lib.Button onClick={() => setLeftOpen(false)}>닫기</Lib.Button>
+            </div>
           </Lib.Slider>
         </div>
       ),
-      description: 'side = left',
-      code: `<Lib.Slider isOpen={open} onClose={close} side="left">...</Lib.Slider>`
+      description: '왼쪽에서 열리는 빈 슬라이더',
+      code: `<Lib.Slider isOpen={open} onClose={close} side="left"><div className="p-3 text-right"><Lib.Button onClick={close}>닫기</Lib.Button></div></Lib.Slider>`
+    },
+    {
+      component: (
+        <div>
+          <Lib.Button onClick={() => setTopOpen(true)}>위쪽 빈 슬라이더</Lib.Button>
+          <Lib.Slider isOpen={topOpen} onClose={() => setTopOpen(false)} side="top">
+            <div className="p-3 text-right">
+              <Lib.Button onClick={() => setTopOpen(false)}>닫기</Lib.Button>
+            </div>
+          </Lib.Slider>
+        </div>
+      ),
+      description: '위쪽에서 열리는 빈 슬라이더',
+      code: `<Lib.Slider isOpen={open} onClose={close} side="top"><div className="p-3 text-right"><Lib.Button onClick={close}>닫기</Lib.Button></div></Lib.Slider>`
+    },
+    {
+      component: (
+        <div>
+          <Lib.Button onClick={() => setBottomOpen(true)}>아래쪽 빈 슬라이더</Lib.Button>
+          <Lib.Slider isOpen={bottomOpen} onClose={() => setBottomOpen(false)} side="bottom">
+            <div className="p-3 text-right">
+              <Lib.Button onClick={() => setBottomOpen(false)}>닫기</Lib.Button>
+            </div>
+          </Lib.Slider>
+        </div>
+      ),
+      description: '아래쪽에서 열리는 빈 슬라이더',
+      code: `<Lib.Slider isOpen={open} onClose={close} side="bottom"><div className="p-3 text-right"><Lib.Button onClick={close}>닫기</Lib.Button></div></Lib.Slider>`
+    },
+    {
+      component: (
+        <div>
+          <Lib.Button onClick={() => setCardOpen(true)}>카드 슬라이더</Lib.Button>
+          <Lib.Slider isOpen={cardOpen} onClose={() => setCardOpen(false)} side="right">
+            <Lib.Card
+              title="카드 샘플"
+              footer={<Lib.Button onClick={() => setCardOpen(false)}>닫기</Lib.Button>}
+            >
+              <p>슬라이더 안 카드</p>
+            </Lib.Card>
+          </Lib.Slider>
+        </div>
+      ),
+      description: '카드 컴포넌트를 포함한 슬라이더',
+      code: `<Lib.Slider isOpen={open} onClose={close} side="right"><Lib.Card title="카드 샘플" footer={<Lib.Button onClick={close}>닫기</Lib.Button>}>슬라이더 안 카드</Lib.Card></Lib.Slider>`
+    },
+    {
+      component: (
+        <div>
+          <Lib.Button onClick={() => setMenuOpen(true)}>메뉴 슬라이더</Lib.Button>
+          <Lib.Slider isOpen={menuOpen} onClose={() => setMenuOpen(false)} side="left">
+            <ul className="p-4 space-y-2">
+              <li><a href="#" className="block">메뉴 1</a></li>
+              <li><a href="#" className="block">메뉴 2</a></li>
+              <li><a href="#" className="block">메뉴 3</a></li>
+            </ul>
+            <div className="p-3 text-right">
+              <Lib.Button onClick={() => setMenuOpen(false)}>닫기</Lib.Button>
+            </div>
+          </Lib.Slider>
+        </div>
+      ),
+      description: '리스트 메뉴를 담은 슬라이더',
+      code: `<Lib.Slider isOpen={open} onClose={close} side="left"><ul className="p-4 space-y-2"><li>...</li></ul><div className="p-3 text-right"><Lib.Button onClick={close}>닫기</Lib.Button></div></Lib.Slider>`
     }
   ];
   return examples;


### PR DESCRIPTION
## Summary
- restore CSS-based Slider implementation
- show empty sliders for each direction and add card/menu samples
- document new examples in Slider docs

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c03cb8c0b08320a459749f572be033